### PR TITLE
Add a script to lauch the terminal and documentation

### DIFF
--- a/demo.md
+++ b/demo.md
@@ -1,0 +1,19 @@
+
+## Demo
+
+To run a demo on a single machine you will need:
+
+* Perform the setup described in README.md
+* Install redis
+* execute `start_demo.sh`
+
+## Interacting
+
+Useful commands once the demo is running:
+
+* `screen -ls` - list all the screen sessions that are running
+* `screen -r client` - connect to the screen session running the client
+* `C-a d` - (Read control-a d) detach from the screen - i.e. return to the terminal
+* When in a screen, C-c (control-c) will terminate that program and return you to the terminal
+
+

--- a/start_demo
+++ b/start_demo
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo 'Starting Redis in Screen (redis)'
+screen -dm -S redis redis-server
+sleep 1
+echo 'Starting Work Generator in Screen (work_gen)'
+screen -dm -S work_gen .venv/bin/python src/c21server/work_gen/basic_work_gen.py
+sleep 1
+echo 'Starting Work Server in Screen (work_server)'
+screen -dm -S server .venv/bin/python src/c21server/work_server/work_server.py
+sleep 1
+echo 'Starting Client in Screen (client1)'
+screen -dm -S client1 .venv/bin/python src/c21client/client.py
+sleep 1
+echo 'Starging Dashboard in Screen (dashboard)'
+screen -dm -S dashboard .venv/bin/python src/c21server/dashboard/dashboard_server.py
+
+


### PR DESCRIPTION
The file `start_demo` contains a set of commands to start (in order)
each program in a screen session:

* redis
* work generator
* work server
* 1 client
* dashboard

The file `demo.md` describes how to interact with the screen sessions once
`start_demo` completes.