### PR TITLE
Run all clean commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,6 @@
 # NOTE:  This file MUST use tabs for indentation rather than spaces
 #        If you get an error "*** missing separator. Stop" then you
 #        probably have spaces for indentation.
-#
-#
-# In PyCharm, you can install a plugin for Makefile support that
-# will use tabs
 export PATH:=${PWD}/.venv/bin:${PATH};
 
 all: test static
@@ -18,10 +14,10 @@ static:
 	pylint src tests;
 
 clean:
-	rm -f unit-python.xml
-	rm -f .coverage
+	-rm -f unit-python.xml
+	-rm -f .coverage
 	# Find and remove all __pycache__ folders and all .pyc files (compiled python)
-	find . | grep -E "(__pycache__|\.pyc)" | xargs rm -rfq
-	rm -rf htmlcov
-	rm -rf .pytest_cache
-	rm -rf .vagrant
+	-find . | grep -E "(__pycache__|\.pyc)" | xargs rm -rf
+	-rm -rf htmlcov
+	-rm -rf .pytest_cache
+	-rm -rf .vagrant


### PR DESCRIPTION
If a command fails, then the rest will not run. The changes made allow for all commands to run even if some error.
Additionally, we remove a misplaced q from the Makefile.