### PR TITLE
Add a coverage config file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.:


### PR DESCRIPTION
The addition of the .coveragerc file is used to ignore code in `if __name__ == '__main__':` blocks.
This increases our coverage while ignoring statements that are not testable.