### PR TITLE
Dynamic dashboard

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ install_requires =
     fakeredis >= 1.4.5
     requests-mock >= 1.8.0
     pytest-mock >= 3.5.1
+    Flask-Cors >= 3.0.10
 
 [options.packages.find]
 where=src

--- a/src/c21server/dashboard/dashboard_server.py
+++ b/src/c21server/dashboard/dashboard_server.py
@@ -1,4 +1,5 @@
 from flask import Flask, jsonify, render_template
+from flask_cors import CORS
 from redis import Redis
 
 
@@ -6,6 +7,7 @@ class Dashboard:
     def __init__(self, redis_server):
         self.app = Flask(__name__)
         self.redis = redis_server
+        CORS(self.app, resources={r'/data': {'origins': '*'}})
 
 
 def get_jobs_stats(database):

--- a/src/c21server/dashboard/static/index.js
+++ b/src/c21server/dashboard/static/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const BASE_URL = 'http://127.0.0.1:5000/'
+const BASE_URL = window.location.href;
 
 window.addEventListener('load', function init() {
     setInterval( () => {


### PR DESCRIPTION
- Enabled CORS
- Use window.location.href for BASE_URL instead of hardcoded base URL