### PR TITLE
Client interacts with regulations.gov

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     requests-mock >= 1.8.0
     pytest-mock >= 3.5.1
     Flask-Cors >= 3.0.10
-    dotenv >= 0.17.0
+    python-dotenv >= 0.17.0
 
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,8 @@ install_requires =
     requests-mock >= 1.8.0
     pytest-mock >= 3.5.1
     Flask-Cors >= 3.0.10
+    dotenv >= 0.17.0
+
 
 [options.packages.find]
 where=src

--- a/src/c21client/client.py
+++ b/src/c21client/client.py
@@ -62,7 +62,6 @@ def perform_job(url, api_key):
     url = url + f'?api_key={api_key}'
     print(f'Getting docket at {url}')
     json = assure_request(requests.get, url).json()
-    print(json)
     print('Done with current job!')
     return json
 

--- a/src/c21server/work_gen/basic_work_gen.py
+++ b/src/c21server/work_gen/basic_work_gen.py
@@ -27,6 +27,6 @@ if __name__ == '__main__':
     try:
         redis_database.ping()
         print('Successfully connected to redis')
-        generate_jobs(redis_database, 'src/c21server/data/dockets_0.txt')
+        generate_jobs(redis_database, '../data/dockets_0.txt')
     except redis.exceptions.ConnectionError as r_con_error:
         print('Redis connection error:', r_con_error)

--- a/tests/c21client/test_client.py
+++ b/tests/c21client/test_client.py
@@ -72,9 +72,7 @@ def test_client_sleeps_when_no_jobs_available(mock_requests, mocker):
 def test_client_sends_job_results(mock_requests, mocker):
     client = Client()
     mock_job_id = 1
-    mock_job_result = {'data':
-                       {'id': 1,
-                        'agencyId': 'NOAA'}}
+    mock_job_result = {'data': {'id': 1, 'attributes': {'agencyId': 'NOAA'}}}
     mock_client_id = 999
     read_mock_client_id(mocker, mock_client_id)
 
@@ -118,9 +116,7 @@ def test_client_completes_job_requested(mock_requests, mocker):
         )
         mock_requests.get(
             'http://test.com',
-            json={'data':
-                  {'id': 1,
-                   'agencyId': 'NOAA'}},
+            json={'data': {'id': 1, 'attributes': {'agencyId': 'NOAA'}}},
             status_code=200
         )
 


### PR DESCRIPTION
Please keep in mind a few things with this pull request:

1. The client (here) halts at the portion where it sends job results - this is because it is dependent on the work server correctly receiving the results, which should be coming in through a **different** pull request. 
2. I currently have the jobs sleeping for 0.72 seconds - here is the math: We have 5000 calls in 1 hour (3600000 ms). If we divide 3600000 by 5000, we get 720. This is the amount of time (in ms) that we need to sleep between calls in order to limit the number of calls in an hour to 5000.
3. dockets_0.txt **must be downloaded** in order for the work generator to generate the correct jobs/urls - this must go in a specific directory location as well, specified in the README. The txt file is found in discord. 
4. There may still be some status code things we need to change or other error handling, but for now this is correctly make the calls to regulations.gov and formatting the url correctly. Essentially, the job is performing correctly, but results are not being placed correctly as of now. 
5. All tests pass for now! 
6. This should be tested by running with the other aspects of the work server (that are still being worked on) before this is merged in. 

Please send any feedback - I appreciate it! 
