### PR TITLE
Jobs waiting queue

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -2,21 +2,25 @@
 
 ## Database Format
 
-The database has three hashes, with the names:
+The database has three "tables", with the names:
 
-`jobs_waiting`, `jobs_in_progress`, and `jobs_done`.
+`jobs_waiting_queue`, `jobs_in_progress`, and `jobs_done`.
 
-Each of these hashes will store jobs for clients to process.
+`jobs_waiting_queue` is a list, while 'jobs_in_progress' and 'jobs_done' are hashes.
+Each stores jobs for clients to process.
 
-Keys in the hashes will be integers, the job ids of the jobs.
+Keys will be integers, the job ids of the jobs.
 These keys will be mapped to integers, the values to be processed.
 
 Additionally, the database has an integer value storing the number of clients:
 `total_num_client_ids`.
 
 ## Redis Format
-## `jobs_waiting`
-> { [job_id] : [value] } 
+## `jobs_waiting_queue`
+
+This list holds JSON strings representing each job (a job_id and a url) 
+
+>['{"job_id" :[value], "url": [value] }',  '{"job_id" :[value], "url": [value] }', ... ]
 
 ## `jobs_in_progress`
 > { [job_id] : [value] } 

--- a/src/c21server/dashboard/dashboard_server.py
+++ b/src/c21server/dashboard/dashboard_server.py
@@ -11,7 +11,7 @@ class Dashboard:
 
 
 def get_jobs_stats(database):
-    jobs_waiting = int(database.hlen('jobs_waiting'))
+    jobs_waiting = int(database.llen('jobs_waiting_queue'))
     jobs_in_progress = int(database.hlen('jobs_in_progress'))
     jobs_done = int(database.hlen('jobs_done'))
     jobs_total = jobs_waiting + jobs_in_progress + jobs_done

--- a/src/c21server/work_gen/basic_work_gen.py
+++ b/src/c21server/work_gen/basic_work_gen.py
@@ -1,5 +1,6 @@
-import redis
 import json
+import redis
+
 
 def generate_jobs(database, job_filename, start_key=0):
 
@@ -17,7 +18,7 @@ def generate_jobs(database, job_filename, start_key=0):
 
             # [:-1] is to remove the return character before making the call
             url = url_base + line[:-1]
-            job = {'job_id':start_key, 'url':url}
+            job = {'job_id': start_key, 'url': url}
             database.rpush('jobs_waiting_queue', json.dumps(job))
             start_key += 1
     print(f'I\'ve finished generating work from this file: {job_filename}')

--- a/src/c21server/work_gen/basic_work_gen.py
+++ b/src/c21server/work_gen/basic_work_gen.py
@@ -1,5 +1,5 @@
 import redis
-
+import json
 
 def generate_jobs(database, job_filename, start_key=0):
 
@@ -17,7 +17,8 @@ def generate_jobs(database, job_filename, start_key=0):
 
             # [:-1] is to remove the return character before making the call
             url = url_base + line[:-1]
-            database.hset('jobs_waiting', start_key, url)
+            job = {'job_id':start_key, 'url':url}
+            database.rpush('jobs_waiting_queue', json.dumps(job))
             start_key += 1
     print(f'I\'ve finished generating work from this file: {job_filename}')
 

--- a/tests/c21server/test_dashboard.py
+++ b/tests/c21server/test_dashboard.py
@@ -9,8 +9,8 @@ def fixture_mock_server():
 
 
 def add_mock_data_to_database(database):
-    jobs_waiting = {i: i for i in range(1, 6)}
-    database.hset('jobs_waiting', mapping=jobs_waiting)
+    for job in range(1, 6):
+        database.rpush('jobs_waiting_queue', job)
     jobs_in_progress = {i: i for i in range(6, 10)}
     database.hset('jobs_in_progress', mapping=jobs_in_progress)
     jobs_done = {i: i for i in range(10, 13)}

--- a/tests/c21server/test_work_server.py
+++ b/tests/c21server/test_work_server.py
@@ -76,22 +76,23 @@ def test_get_job_has_no_available_job(mock_server):
 def test_get_job_returns_single_job(mock_server):
     mock_server.redis.incr('total_num_client_ids')
     params = {'client_id': 1}
-    mock_server.redis.hset('jobs_waiting', 1, 2)
+    job = {'job_id':1, 'url':'url'}
+    mock_server.redis.rpush('jobs_waiting_queue', dumps(job))
     response = mock_server.client.get('/get_job', query_string=params)
     assert response.status_code == 200
-    expected = {'job': {'1': '2'}}
+    expected = {'job': {'1': 'url'}}
     assert response.get_json() == expected
 
 
 def test_get_waiting_job_is_now_in_progress_and_not_waiting(mock_server):
     mock_server.redis.incr('total_num_client_ids')
     params = {'client_id': 1}
-    mock_server.redis.hset('jobs_waiting', 2, 3)
+    job = {'job_id':3, 'url':'url'}
+    mock_server.redis.rpush('jobs_waiting_queue', dumps(job))
     mock_server.client.get('/get_job', query_string=params)
-    keys = mock_server.redis.hkeys('jobs_waiting')
-    assert keys == []
+    assert mock_server.redis.llen('jobs_waiting_queue') == 0
     keys = mock_server.redis.hkeys('jobs_in_progress')
-    assert mock_server.redis.hget('jobs_in_progress', keys[0]).decode() == '3'
+    assert mock_server.redis.hget('jobs_in_progress', keys[0]).decode() == 'url'
 
 
 def test_put_results_message_body_contains_no_results(mock_server):

--- a/tests/c21server/test_work_server.py
+++ b/tests/c21server/test_work_server.py
@@ -76,7 +76,7 @@ def test_get_job_has_no_available_job(mock_server):
 def test_get_job_returns_single_job(mock_server):
     mock_server.redis.incr('total_num_client_ids')
     params = {'client_id': 1}
-    job = {'job_id':1, 'url':'url'}
+    job = {'job_id': 1, 'url': 'url'}
     mock_server.redis.rpush('jobs_waiting_queue', dumps(job))
     response = mock_server.client.get('/get_job', query_string=params)
     assert response.status_code == 200
@@ -87,12 +87,13 @@ def test_get_job_returns_single_job(mock_server):
 def test_get_waiting_job_is_now_in_progress_and_not_waiting(mock_server):
     mock_server.redis.incr('total_num_client_ids')
     params = {'client_id': 1}
-    job = {'job_id':3, 'url':'url'}
+    job = {'job_id': 3, 'url': 'url'}
     mock_server.redis.rpush('jobs_waiting_queue', dumps(job))
     mock_server.client.get('/get_job', query_string=params)
     assert mock_server.redis.llen('jobs_waiting_queue') == 0
     keys = mock_server.redis.hkeys('jobs_in_progress')
-    assert mock_server.redis.hget('jobs_in_progress', keys[0]).decode() == 'url'
+    assert mock_server.redis.hget('jobs_in_progress',
+                                  keys[0]).decode() == 'url'
 
 
 def test_put_results_message_body_contains_no_results(mock_server):

--- a/tests/c21server/test_workgen.py
+++ b/tests/c21server/test_workgen.py
@@ -1,8 +1,8 @@
+import json
 from fakeredis import FakeRedis
 import pytest
 from pytest import fixture
 import c21server.work_gen.basic_work_gen as work_gen
-import json
 
 
 @fixture(name='mock_redis')


### PR DESCRIPTION
This PR changes our usage of redis for the jobs_waiting "queue."  The previous version used a hash, and we had to load all the keys each time a client requested a job.  This was far too slow when there were lots of jobs (~2 seconds per request with 400K jobs).

This version uses a list named jobs_waiting_queue.  Each value in the queue is a JSON string of the form {'job_id': <id>, 'url':<ulr>}.  We use the `json` library to convert when adding jobs (workget) and retrieving jobs (work server).
