### PR TITLE
Implement failed jobs.

### DIFF
--- a/mirrulations-client/src/mirrclient/client.py
+++ b/mirrulations-client/src/mirrclient/client.py
@@ -38,9 +38,14 @@ class Client:
 
     def send_job_results(self, job_id, job_result):
         endpoint = f'{self.url}/put_results'
-        data = {'directory': get_output_path(job_result),
-                'job_id': job_id,
-                'results': job_result}
+        if 'errors' in job_result:
+            data = {'job_id': job_id,
+                    'results': job_result
+                    }
+        else:
+            data = {'directory': get_output_path(job_result),
+                    'job_id': job_id,
+                    'results': job_result}
         params = {'client_id': self.client_id}
         print(dumps(data))
         assure_request(requests.put, endpoint, json=dumps(data), params=params)
@@ -94,7 +99,9 @@ def attempt_request(request, url, sleep_time, **kwargs):
         if err.response.status_code == 400:
             print('Endpoint not found!')
             return {'error': 'Endpoint not found'}
-        time.sleep(sleep_time)
+        if err.response.status_code >= 500:
+            print('Regulations.gov internal error')
+            return response
     else:
         return response
     return None

--- a/mirrulations-work-server/src/mirrserver/work_server.py
+++ b/mirrulations-work-server/src/mirrserver/work_server.py
@@ -79,7 +79,7 @@ def put_results(workserver, data):
     success, *values = check_request_had_valid_client_id(workserver, client_id)
     if not success:
         return False, values[0], values[1]
-    if 'error' in data['results']:
+    if 'error' in data['results'] or 'errors' in data['results']:
         job_id = data['job_id']
         result = workserver.redis.hget('jobs_in_progress', job_id)
         workserver.redis.hdel('jobs_in_progress', job_id)

--- a/mirrulations-work-server/tests/test_work_server.py
+++ b/mirrulations-work-server/tests/test_work_server.py
@@ -186,6 +186,31 @@ def test_put_results_returns_correct_job(mock_server, mocker):
     assert len(mock_server.data.added) == 1
 
 
+def test_put_results_returns_500_error_from_regulations(mock_server, mocker):
+
+    mock_write_results(mocker)
+    mock_server.redis.hset('jobs_in_progress', 2, 3)
+    mock_server.redis.hset('client_jobs', 2, 1)
+    mock_server.redis.set('total_num_client_ids', 1)
+
+    data = dumps({'job_id': 2, 'results': {"errors": [{
+        "status": "500",
+        "title": "INTERNAL_SERVER_ERROR",
+        "detail": "Incorrect result size: expected 1, actual 2"}]}})
+
+    params = {'client_id': 1}
+    response = mock_server.client.put('/put_results',
+                                      json=data, query_string=params)
+    assert response.status_code == 200
+    # Not sure this is the best way to do this...
+    expected = {'success': 'The job was successfully completed'}
+    assert response.get_json() == expected
+
+    assert mock_server.redis.hlen('invalid_jobs') == 1
+    assert mock_server.redis.hlen('jobs_done') == 0
+    assert mock_server.redis.hlen('jobs_in_progress') == 0
+
+
 def test_server_handles_client_error_to_access_api_endpoint(mock_server):
     mock_server.redis.set('total_num_client_ids', 1)
     mock_server.redis.hset('jobs_in_progress', 2, 3)


### PR DESCRIPTION
If regulations.gov returns a 500 error, the client will return the error
message to the server.  The server, in turn, will move the job to the
invalid_jobs collection in redis.