### PR TITLE
Docker improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
     image: redis
     volumes:
       - "~/data/redis:/data"
+    ports:
+      - "6379:6379"
   mongo:
     image: mongo
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,83 +36,100 @@ services:
       context: .
       dockerfile: mirrulations-client/Dockerfile
     env_file: env_files/client1.env
+    restart: always
   client2:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
     env_file: env_files/client2.env
+    restart: always
   client3:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
     env_file: env_files/client3.env
+    restart: always
   client4:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
     env_file: env_files/client4.env
+    restart: always
   client5:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
     env_file: env_files/client5.env
+    restart: always
   client6:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
     env_file: env_files/client6.env
+    restart: always
   client7:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
     env_file: env_files/client7.env
+    restart: always
   client8:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
     env_file: env_files/client8.env
+    restart: always
   client9:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
     env_file: env_files/client9.env
+    restart: always
   client10:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
     env_file: env_files/client10.env
+    restart: always
   client11:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
     env_file: env_files/client11.env
+    restart: always
   client12:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
     env_file: env_files/client12.env
+    restart: always
   client13:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
     env_file: env_files/client13.env
+    restart: always
   client14:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
     env_file: env_files/client14.env
+    restart: always
   client15:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
     env_file: env_files/client15.env
+    restart: always
   client16:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
     env_file: env_files/client16.env
+    restart: always
   client17:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
     env_file: env_files/client17.env
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     image: mongo
     volumes:
       - "~/data/db:/data/db"
+    ports:
+      - "27017:27017"
   work_generator:
     build:
       context: .


### PR DESCRIPTION

* Auto-restart clients on error.  This is a work-around to the fact that the clients periodically crash.  The issue is in the handling of non-200 status codes.  Fixing it would take a significant rework of the code that I don't have time for right now.  This will ensure that a client gets restarted by Docker if it crashes.  NOTE:  The job in progress at the crash will not be completed.  We will have to clean them up at some point to ensure we have all the data.
* Expose mongo and redis ports on localhost.  This is so that we can explore the data directly from the capstone box rather than having to go into the Docker containers.  Neither port is expose off campus, so we are not exposing data.  There may be some risk with exposing data on campus, but it is only within the cslab network.
* 